### PR TITLE
Add "j" and "k" for navigation in interactive mode (vim motions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ In interactive mode, use the following controls:
 
 | Key         | Action                              |
 |-------------|-------------------------------------|
-| `↑/↓`       | Navigate the file list              |
+| `↑/↓/j/k`   | Navigate the file list              |
 | `SPACE`     | Toggle selection of the current file |
 | `a`         | Select or deselect all files        |
 | `ENTER`     | Confirm the selection and proceed   |

--- a/cli_tool_gptree/main.py
+++ b/cli_tool_gptree/main.py
@@ -118,7 +118,7 @@ def interactive_file_selector(file_list):
 
         while True:
             stdscr.clear()
-            stdscr.addstr(0, 0, "Use ↑/↓ to scroll, SPACE to toggle selection, 'a' to select all, ENTER to confirm, ESC to quit")
+            stdscr.addstr(0, 0, "Use ↑/↓/j/k to scroll, SPACE to toggle selection, 'a' to select all, ENTER to confirm, ESC to quit")
             stdscr.addstr(1, 0, "-" * 80)
 
             for idx in range(display_limit):
@@ -147,12 +147,12 @@ def interactive_file_selector(file_list):
             stdscr.addstr(display_limit + 4, 0, f"Selected: {len(selected_files)} / {len(file_list)}")
 
             key = stdscr.getch()
-            if key == curses.KEY_DOWN:
+            if key in (curses.KEY_DOWN, ord('j')):
                 if current_row < max_rows - 1:
                     current_row += 1
                     if current_row >= offset + display_limit:
                         offset += 1
-            elif key == curses.KEY_UP:
+            elif key in (curses.KEY_UP, ord('k')):
                 if current_row > 0:
                     current_row -= 1
                     if current_row < offset:


### PR DESCRIPTION
This PR offers the possibility to navigate the interactive mode with vim motions.

It looks like this:
<img width="578" alt="image" src="https://github.com/user-attachments/assets/72ac2404-fdb9-4d2f-b5c3-c12fabc8c017" />
